### PR TITLE
#369 README.md clarification for promises polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ localforage.setItem('key', 'value').then(function(value) {
 
 localForage relies on native [ES6 Promises](http://www.promisejs.org/), but
 [ships with an awesome polyfill](https://github.com/jakearchibald/ES6-Promises)
-for browsers that don't support ES6 Promises yet.
+for browsers that don't support ES6 Promises yet. If you're already using your own polyfill for promises, you could use localForage's no-promises-pollyfill version:
+
+```html
+<script src="localforage.nopromises.js"></script>
+```
+
 
 ## Storing Blobs, TypedArrays, and other JS objects
 


### PR DESCRIPTION
As mentioned in Issue #369, there's some confusion in terms of what localForage.nopromises.js really does. This PR intends to add a bit of clarification to the README file portion corresponding to Promises:

> [...] If you're already using your own polyfill for promises, you could use localForage's no-promises-pollyfill version:
> 
> ``` html
> <script src="localforage.nopromises.js"></script>
> ```
